### PR TITLE
Change `const` to `var` inside helper

### DIFF
--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -684,7 +684,7 @@ helpers.set = () => template.program.ast`
   }
 
   export default function _set(target, property, value, receiver, isStrict) {
-    const s = set(target, property, value, receiver || target);
+    var s = set(target, property, value, receiver || target);
     if (!s && isStrict) {
       throw new Error('failed to set property');
     }


### PR DESCRIPTION
One of the helpers has a `const` rather than a `var` in it's body, which cause our minifier (closure compiler) to throw an error as it is set to ES5. 

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  | No
| License                  | MIT

